### PR TITLE
Update avm.virtual_network.tf

### DIFF
--- a/labs/part02-virtual-network/avm.virtual_network.tf
+++ b/labs/part02-virtual-network/avm.virtual_network.tf
@@ -4,6 +4,6 @@ module "virtual_network" {
   resource_group_name           = azurerm_resource_group.this.name
   subnets                       = local.subnets
   virtual_network_address_space = [local.virtual_network_address_space]
-  vnet_location                 = var.location
-  vnet_name                     = local.virtual_network_name
+  location                      = var.location
+  name                          = local.virtual_network_name
 }


### PR DESCRIPTION
vnet_ prefix is removed for "location" and "name". Otherwise Terraform fails with "parameter is not expected here"

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Parameters are defined without vnet_ prefix in Terraform registry. Using the prefixes breaks Terraform Apply 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code


* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Terraform Init
terraform plan -out tfplan
terraform apply -auto-approve

## What to Check
Verify that the following are valid
* Vnet deployment

## Other Information
<!-- Add any other helpful information that may be needed here. -->